### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -4,7 +4,7 @@ module "vpc" {
 
   for_each = local.private_enabled ? local.vpc_environment_names : toset([])
 
-  component   = "vpc"
+  component   = var.vpc_component_name
   environment = each.value
 
   context = module.this.context

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -89,3 +89,9 @@ variable "dns_soa_config" {
   EOT
   default     = "awsdns-hostmaster.amazon.com. 1 7200 900 1209600 60"
 }
+
+variable "vpc_component_name" {
+  type        = string
+  description = "The name of a VPC component"
+  default     = "vpc"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variable `vpc_component_name`.
* Variable defaults to preserving the behaviour of the current version.
* Remote state uses this variable to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to set the VPC component name, allowing users to customize this value as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->